### PR TITLE
Remove assumptions about git and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,10 @@ The follow-up to [`npm2yarn`](https://github.com/mixmaxhq/npm2yarn). See https:/
 
 `deyarn`:
 
-1. Checks out the `master` branch
-2. Pulls the latest changes
-3. Checks out a new branch, `deyarnify`, overwriting any existing `deyarnify` branch
-4. Removes `yarn.lock` if it exists
-5. Removes `node_modules` to avoid any installation conflicts
-6. Installs your project dependencies using `npm`, generating a `package-lock.json` file
-7. Runs `npm test` as a sanity check
-8. Stages the changes made
-9. Logs a list of manual steps to be taken to complete the transition
+1. Removes `yarn.lock` if it exists
+2. Removes `node_modules` to avoid any installation conflicts
+3. Installs your project dependencies using `npm`, generating a `package-lock.json` file
+4. Logs a list of manual steps to be taken to complete the transition
 
 This conversion will likely involve the upgrading of some/many of your transitive dependencies, so make sure to test thoroughly! :)
 
@@ -32,7 +27,6 @@ $ yarn global add deyarn
 
 ## Usage
 
-(in the directory of the project to convert, which must be a Git repository)
 ```
 $ deyarn
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ $ yarn global add deyarn
 
 ## Usage
 
+(in the directory of the project to convert)
+
 ```
 $ deyarn
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -8,25 +8,7 @@ const editJsonFile = require('edit-json-file');
 
 
 module.exports = () => {
-  console.log(chalk.magenta('\nnpm2yarn.js...\n'));
-
-  // Git setup.
-  console.log(chalk.blue('\nGit setup...'));
-  console.log(chalk.blue('Checking out master'));
-  spawnSync('git', ['checkout', 'master'], {
-    // Write to this process's stdout.
-    stdio: 'inherit'
-  });
-
-  console.log(chalk.blue('Pulling the latest changes'));
-  spawnSync('git', ['pull'], {
-    stdio: 'inherit'
-  });
-
-  console.log(chalk.blue('Checking out `deyarnify`'));
-  spawnSync('git', ['checkout', '-B', 'deyarnify'], {
-    stdio: 'inherit'
-  });
+  console.log(chalk.magenta('\ndeyarn...\n'));
 
   const yarnLockPath = `${process.cwd()}/yarn.lock`;
   if (fs.existsSync(yarnLockPath)) {
@@ -64,12 +46,6 @@ module.exports = () => {
     stdio: 'inherit'
   });
 
-  // Run tests.
-  console.log(chalk.blue('\nRunning `npm test`.'));
-  spawnSync('npm', ['test'], {
-    stdio: 'inherit'
-  });
-
   // Require that users of this package use npm rather than Yarn since it's easy to forget :).
   const packageJsonPath = `${process.cwd()}/package.json`;
   const packageJson = editJsonFile(packageJsonPath, {
@@ -77,25 +53,16 @@ module.exports = () => {
   });
   packageJson.set('engines.yarn', 'YARN NO LONGER USED - use npm instead.');
 
-  // Stage changes.
-  console.log(chalk.blue('\nStaging changes.'));
-  spawnSync('git', ['add', '.'], {
-    stdio: 'inherit'
-  });
-  spawnSync('git', ['status'], {
-    stdio: 'inherit'
-  });
-
   // Output success.
 
   console.log(chalk.green('\n\nSuccess!\n'));
   console.log('NEXT STEPS:');
-  console.log('  1. Update package.json scripts to use npm if necessary:');
+  console.log('  1. Perform any testing to ensure that package updates were not problematic.');
+  console.log('  2. Update package.json scripts to use npm if necessary:');
   console.log('    ', chalk.cyan(JSON.stringify(packageJson.get('scripts'))));
-  console.log('  2. Update the README if necessary');
+  console.log('  3. Update your CI configuration if necessary');
+  console.log('  4. Update the README if necessary');
   console.log('    - Add preferred npm-install instruction');
   console.log('    - Update any other Yarn commands to use npm instead');
-  console.log('  3. Update your CI configuration if necessary');
-  console.log('  4. Perform any additional testing to ensure that package updates were not problematic.');
   console.log('  5. Commit the made changes');
 };


### PR DESCRIPTION
Perhaps unwelcome (sorry if so) this PR does two things:
- Removes assumption that you're using `git` and want this package to do *anything* with source control.
- Remove assumption that you're using the `test` npm script to run your tests.

It simply removes `yarn`, does an `npm install` and suggests you run your tests and update anything else you might want to do to make sure everything is good.