### PR TITLE
remove the engines.yarn path from the package json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deyarn",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -473,14 +473,14 @@
       }
     },
     "edit-json-file": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/edit-json-file/-/edit-json-file-1.0.8.tgz",
-      "integrity": "sha512-40Yg6GkZKpKy6ocutmL5/7SvOzRmNCaYey5iAP221eo/np+KUuvnuG0duRCMyXtePVJ8kOSgFvh2oo7hivA8xg==",
+      "version": "github:acconrad/edit-json-file#d27f2330a75e9d3a1996d0bc65f2a770a41d5e08",
+      "from": "github:acconrad/edit-json-file#master",
       "requires": {
         "find-value": "^1.0.3",
         "iterate-object": "^1.3.2",
         "r-json": "^1.2.5",
         "set-value": "^0.4.0",
+        "unset-value": "1.0.0",
         "w-json": "^1.3.5"
       }
     },
@@ -817,6 +817,11 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -883,6 +888,31 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-value": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "requires": {
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "has-values": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
     },
     "iconv-lite": {
       "version": "0.4.21",
@@ -1048,8 +1078,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1646,6 +1675,15 @@
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
       "dev": true,
       "optional": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deyarn",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A command-line tool for converting projects that use Yarn to npm.",
   "bin": "bin/deyarn.js",
   "main": "src/index.js",
@@ -16,6 +16,6 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "del": "^3.0.0",
-    "edit-json-file": "^1.0.8"
+    "edit-json-file": "acconrad/edit-json-file#master"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ module.exports = () => {
   const packageJson = editJsonFile(packageJsonPath, {
     autosave: true
   });
-  packageJson.set('engines.yarn', 'YARN NO LONGER USED - use npm instead.');
+  packageJson.unset('engines.yarn');
 
   // Output success.
 


### PR DESCRIPTION
Fixes issue #7 by `unset`-ing the line rather than modifying it. Only valid SEMVER formatting is allowed for engine values, so since `yarn` no longer exists it should just simply be removed instead.