### PR TITLE
Specify npm engine in package.json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ module.exports = () => {
     autosave: true
   });
   packageJson.set('engines.yarn', 'YARN NO LONGER USED - use npm instead.');
+  packageJson.set('engines.npm', '>= 5.1');
 
   // Output success.
 


### PR DESCRIPTION
`package-lock.json` was introduced in NPM 5 and considered stable by `5.1.x`. This addition will ensure that yarn users aren't using a very old version of `npm` that would ignore the `package-lock.json`.